### PR TITLE
stop resetting client data back to empty on login

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/CounterModClient.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/CounterModClient.kt
@@ -19,14 +19,6 @@ object CounterModClient {
     var clientCounterData: ClientCounterManager = ClientCounterManager(mutableMapOf())
     var config: ClientCounterConfig = ConfigBuilder.load(ClientCounterConfig::class.java, "${MOD_ID}_client")
 
-    @EventBusSubscriber
-    object Registration {
-        @SubscribeEvent
-        fun onLogin(e: PlayerLoggedInEvent) {
-            clientCounterData = ClientCounterManager(mutableMapOf())
-        }
-    }
-
     @EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
     object ModRegistration {
         @SubscribeEvent


### PR DESCRIPTION
unnecessary due to initialization of variable, and - in a race condition with the data coming from the backend - was sometimes overriding what the backend gave
