### PR TITLE
fixed doubling events

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/CounterMod.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/CounterMod.kt
@@ -29,6 +29,7 @@ object CounterMod {
 
     private var logger: Logger = LogManager.getLogger(MOD_ID)
     var config: CounterConfig = ConfigBuilder.load(CounterConfig::class.java, MOD_ID)
+    var eventsInitialized = false
 
     @EventBusSubscriber
     object Registration {
@@ -36,7 +37,6 @@ object CounterMod {
         fun onInit(e: ServerStartedEvent) {
             ServerStartingHandler.handle(e)
             CounterRegistry
-            CounterEventHandlers.register()
             saveTasks[PlayerInstancedDataStores.COUNTER] = ScheduledTask.Builder()
                 .execute { Cobblemon.playerDataManager.saveAllOfOneType(PlayerInstancedDataStores.COUNTER) }
                 .delay(30f)
@@ -44,6 +44,9 @@ object CounterMod {
                 .infiniteIterations()
                 .tracker(ServerTaskTracker)
                 .build()
+            if (eventsInitialized) return
+            eventsInitialized = true
+            CounterEventHandlers.register()
         }
     }
 


### PR DESCRIPTION
I'm registering them when the server starts. However, if the player leaves a world and joins again without closing the game, this counts as the singleplayer server loading again. The event listeners get attached each time the server starts, so now we have a simple latch that says we already loaded them and don't do it again.
