### PR TITLE
v1.5.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,6 @@ minecraft_version=1.21.1
 yarn_mappings=1.21.1+build.3
 loader_version=0.16.9
 
-neoforge_version=21.1.66
-kff_version=5.3.0
+neoforge_version=21.1.181
+kff_version=5.8.0
 cobblemon_version=1.6.1+1.21.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx4G
 loom.platform=neoforge
 
-mod_version=1.6-neoforge-1.5.0
+mod_version=1.6-neoforge-1.5.1
 maven_group=us.timinc.mc.cobblemon
 archives_base_name=counter
 

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/CounterMod.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/CounterMod.kt
@@ -13,6 +13,7 @@ import net.minecraft.resources.ResourceLocation
 import net.neoforged.bus.api.SubscribeEvent
 import net.neoforged.fml.common.EventBusSubscriber
 import net.neoforged.fml.common.Mod
+import net.neoforged.neoforge.common.NeoForge
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent
 import net.neoforged.neoforge.registries.DeferredRegister
 import net.neoforged.neoforge.registries.RegisterEvent
@@ -59,6 +60,8 @@ object CounterMod {
     init {
         with(MOD_BUS) {
             this@CounterMod.commandArgumentTypes.register(this)
+            addListener(::registerItems)
+            addListener(::onCreativeTabsModification)
         }
         AppendageCondition.registerAppendage(SpawningCondition::class.java, CountSpawningCondition::class.java)
         CounterEventHandlers.register()
@@ -75,17 +78,12 @@ object CounterMod {
             .build()
     }
 
-    @EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
-    object ModRegistration {
-        @SubscribeEvent
-        fun registerItems(e: RegisterEvent) {
-            CounterItems
-        }
+    fun registerItems(e: RegisterEvent) {
+        CounterItems
+    }
 
-        @SubscribeEvent
-        fun onCreativeTabsModification(e: BuildCreativeModeTabContentsEvent) {
-            CounterItems.registerTabs(e)
-        }
+    fun onCreativeTabsModification(e: BuildCreativeModeTabContentsEvent) {
+        CounterItems.registerTabs(e)
     }
 
     fun debug(msg: String) {

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/CounterMod.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/CounterMod.kt
@@ -10,10 +10,7 @@ import net.minecraft.commands.synchronization.ArgumentTypeInfos
 import net.minecraft.commands.synchronization.SingletonArgumentInfo
 import net.minecraft.core.registries.Registries
 import net.minecraft.resources.ResourceLocation
-import net.neoforged.bus.api.SubscribeEvent
-import net.neoforged.fml.common.EventBusSubscriber
 import net.neoforged.fml.common.Mod
-import net.neoforged.neoforge.common.NeoForge
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent
 import net.neoforged.neoforge.registries.DeferredRegister
 import net.neoforged.neoforge.registries.RegisterEvent

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/CounterModClient.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/CounterModClient.kt
@@ -1,10 +1,7 @@
 package us.timinc.mc.cobblemon.counter
 
 import com.cobblemon.mod.common.client.tooltips.TooltipManager
-import net.neoforged.bus.api.SubscribeEvent
-import net.neoforged.fml.common.EventBusSubscriber
 import net.neoforged.fml.common.Mod
-import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent
 import us.timinc.mc.cobblemon.counter.CounterMod.MOD_ID
 import us.timinc.mc.cobblemon.counter.api.ClientCounterManager
 import us.timinc.mc.cobblemon.counter.config.ClientCounterConfig
@@ -17,12 +14,8 @@ object CounterModClient {
     var clientCounterData: ClientCounterManager = ClientCounterManager(mutableMapOf(), emptySet())
     var config: ClientCounterConfig = ConfigBuilder.load(ClientCounterConfig::class.java, "${MOD_ID}_client")
 
-    @EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
-    object ModRegistration {
-        @SubscribeEvent
-        fun onSetup(e: FMLClientSetupEvent) {
-            PlayerInstancedDataStores.COUNTER
-            TooltipManager.registerTooltipGenerator(CounterTooltipGenerator)
-        }
+    init {
+        PlayerInstancedDataStores.COUNTER
+        TooltipManager.registerTooltipGenerator(CounterTooltipGenerator)
     }
 }

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -4,7 +4,7 @@ license = "MIT"
 
 [[mods]]
 modId = "cobbled_counter"
-version = "1.6-neoforge-1.5.0"
+version = "1.6-neoforge-1.5.1"
 displayName = "Cobblemon Counter"
 authors = "timinc aka Timothy Metcalfe"
 description = '''


### PR DESCRIPTION
* Moved event handler registration from annotations to init. Change precipitated by an oddity in newer versions of KFF/NF that caused annotation-based event registration to fail (looks like NF removed access to something? idk). This should work across versions.